### PR TITLE
Properly implementing binary methods

### DIFF
--- a/src/Uuid.ts
+++ b/src/Uuid.ts
@@ -27,30 +27,32 @@ export class Uuid implements UuidInterface
 
   public static fromBytes (uuid: string): UuidInterface
   {
-    if (uuid.indexOf('0x') === 0) {
-      uuid = uuid.substr(2).toLowerCase();
+    let result = '';
+
+    for (let i = 0; i < uuid.length; i++) {
+      result += uuid.charCodeAt(i).toString(16);
+
+      switch (i) {
+        case 3:
+        case 5:
+        case 7:
+        case 9:
+          result += '-';
+          break;
+      }
     }
 
-    const newUuid = uuid.substr(0, 8)
-      + '-'
-      + uuid.substr(8, 4)
-      + '-'
-      + uuid.substr(12, 4)
-      + '-'
-      + uuid.substr(16, 4)
-      + '-'
-      + uuid.substr(20, 12);
-
-    return new Uuid(parse(newUuid));
+    return new Uuid(parse(result));
   }
 
   public getBytes (): string
   {
-    let bytes = stringify(this.uuid);
-    bytes = bytes.replace(/-/g, '').toUpperCase();
-    bytes = '0x' + bytes;
+    let bytes = '';
+    for (let i = 0; i < this.uuid.length; i++) {
+      bytes += String.fromCharCode(this.uuid[i]);
+    }
 
-    return bytes;
+    return bytes.replace(' ', '');
   }
 
   public static uuid4 (): UuidInterface

--- a/test/src/Uuid.test.ts
+++ b/test/src/Uuid.test.ts
@@ -2,10 +2,13 @@ import { Uuid } from '../../src/Uuid';
 import { v4 as uuid4, parse } from 'uuid';
 
 describe('Uuid', () => {
-  it('Creates Uuid object from string', () => {
-    const uuid = Uuid.fromString('69755997-69c3-4bc6-b475-178d2766a651');
+  const byteString = 'iuYiÃKÆ´u\'f¦Q';
+  const hexString = '69755997-69c3-4bc6-b475-178d2766a651';
 
-    expect(uuid.getUuid()).toEqual(parse('69755997-69c3-4bc6-b475-178d2766a651'));
+  it('Creates Uuid object from string', () => {
+    const uuid = Uuid.fromString(hexString);
+
+    expect(uuid.getUuid()).toEqual(parse(hexString));
   });
 
   it('Returns a Uuid string from Uuid object', () => {
@@ -16,15 +19,15 @@ describe('Uuid', () => {
   });
 
   it('Creates Uuid object from byte string', () => {
-    const uuid = Uuid.fromBytes('0x6975599769C34BC6B475178D2766A651');
+    const uuid = Uuid.fromBytes(byteString);
 
-    expect(uuid.getUuid()).toEqual(parse('69755997-69c3-4bc6-b475-178d2766a651'));
+    expect(uuid.getUuid()).toEqual(parse(hexString));
   });
 
   it('Returns a Uuid byte string from Uuid object', () => {
-    const uuid = new Uuid(parse('69755997-69c3-4bc6-b475-178d2766a651'));
+    const uuid = new Uuid(parse(hexString));
 
-    expect(uuid.getBytes()).toEqual('0x6975599769C34BC6B475178D2766A651');
+    expect(uuid.getBytes()).toEqual(byteString);
   });
 
   it('Creates a randomly generated Uuid', () => {


### PR DESCRIPTION
# Properly implementing binary methods

## Description

Previously I was converting to hex strings which was incorrect, now I am converting to byte strings that can be saved in `BINARY(16)` columns in a database
